### PR TITLE
Added logging at critical points throughout the nject code base

### DIFF
--- a/lib/nject.js
+++ b/lib/nject.js
@@ -16,120 +16,167 @@ var STATES = {
 
   // the tree enters an error state if any error occurs during the resolution process
   ERROR : 'ERROR'
-}
+};
 
 var Tree = function () {
   // tracks registered constants and dependencies
   this._registry = {};
+
   // tracks resolved dependencies
   this._resolved = {};
 
-  this._state = STATES.REGISTERING
-}
+  // Initial state.  Should never return to this state once it transitions
+  // to any other state.
+  this._state = STATES.REGISTERING;
+};
 
-_.extend(Tree, EventEmitter)
-_.extend(Tree.prototype, EventEmitter.prototype)
+_.extend(Tree, EventEmitter);
+_.extend(Tree.prototype, EventEmitter.prototype);
 
 // indicates the name of the injectable constant that will make a module resolve asynchronously. Can be overridden
 // on the prototype, or on an instance.
-Tree.prototype._asyncConstant = '_done'
+Tree.prototype._asyncConstant = '_done';
 // time in ms before asynchronous resolution will fail with a timeout. Can be disabled by setting to <= 0
-Tree.prototype._asyncTimeout = 10000
+Tree.prototype._asyncTimeout = 10000;
 // time in ms before asynchronous destroy handlers will fail with a timeout. Can be disabled by setting to <= 0
-Tree.prototype._destroyTimeout = 10000
+Tree.prototype._destroyTimeout = 10000;
 
-/*
- Registers a constant - a dependency that does not need to be resolved
- key String name of the dependency
- value * the value that will be injected into modules that depend on this
+/**
+ * Registers the given value with the given @key name.  If the @key
+ * is a plain object it will be traversed using the values as constants
+ * and the keys as the name for each of the values.
+ *
+ * A constant dependency does not need to be resolved, the value that
+ * will be injected into modules that depend on this value will be
+ * provided unprocessed, and simply as the value passed to this method.
+ *
+ * @param key {String|Object} - name of the value or an object containing
+ *                              many key/value pairs.
+ * @param value {*} - the value to inject as parameter during resolution.
+ * @returns {*} - this tree, allowing the further chaining.
  */
 Tree.prototype.constant = function (key, value) {
-  var self = this
+  var self = this;
 
-  if(self._state == STATES.RESOLVING) {
-    var msg = 'Cannot register a constant after tree resolution has begun.'
-    return emitError(self, msg)
+  if (self._state != STATES.REGISTERING) {
+    return emitError(
+      self, 'Cannot register a constant after tree resolution has begun.');
   }
+
+  emitLog(self, LOG_LEVEL.INFO, "Registering constant: {0}", key);
 
   if (_.isObject(key)) {
-    return _.each(key, function (v, k) {
-      self.constant(k, v)
-    });
+    emitLog(this, LOG_LEVEL.INFO, "Registering key/value pairs as constants.")
+    _.each(key, function (v, k) { self.constant(k, v); });
+
+    return this; // Consistent return value type (chainable).
   }
+
   this._registry[key] = {
     dependencies: [],
     constant: value,
     identifier: key,
+    isConstant: true,  // <= the constant value may it self be 'falsy'
     isAsync: false
-  }
-}
+  };
 
-/*
-Registers a module - a function whose arguments are dependencies that need to be resolved and injected at resolution time
-key String name of dependency
-fn Function The DI function for this module. Variable names matter. The variable name for each argument in the function should correspond to a dependency or constant that will be registered with nject.
-opts String || Object registration options
+  return this;
+};
+
+/**
+ * Extracts from the given function definition (.toString()) the
+ * names of it's parameters to later match those parameters to
+ * registered injectables.
+ *
+ * @param fn {Function} - A function definition to extract
+ *    paramter names from.
+ * @returns {Array[Strings]} - Names of parameters required by the
+ *    given function, minus any empty values, which is to say,
+ *    that if the parameter list is empty the array will be empty.
+ */
+Tree.prototype.findDependencies = function(fn) {
+  var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
+  var FN_ARG_SPLIT = /,/;
+  var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+
+  var fnText = fn.toString().replace(STRIP_COMMENTS, '');
+  var argDecl = fnText.match(FN_ARGS);
+  var dependencies = argDecl[1].split(FN_ARG_SPLIT);
+
+  return _.compact(_.invoke(dependencies, 'trim'));
+};
+
+/**
+ * Registers a module, a function, whose arguments are dependencies that
+ * need to be resolved and injected at resolution time.
+ *
+ * @param key {String} - name of dependency.
+ *
+ * @param fn {Function} - The DI function for this module. Variable names
+ * matter. The variable name for each argument in the function should
+ * correspond to a dependency or constant that will be registered with
+ * nject.
+ *
+ * @param opts {String|Object} - registration options.  If a string, then it's
+ * used as an identifier during error reporting where a stack trace from
+ * within nject might be clear.  An object can declare the string value
+ * as 'identifier', but also contain a property 'aggregateOn' that
+ * informs inject to include the injectable as a value on a property of
+ * the resulting resolved symbols with that given name as well it's
+ * formal name given as key.
+ *
+ * @returns {*}
  */
 Tree.prototype.register = function (key, fn, opts) {
-  var self = this;
+  var self = this, msg;
 
-  if(self._state == STATES.RESOLVING) {
-    var msg = 'Cannot register a module after tree resolution has begun.'
-    return emitError(self, msg)
+  if (self._state == STATES.RESOLVING) {
+    msg = 'Cannot register a module after tree resolution has begun.';
+    return emitError(self, msg);
   }
 
   if (_.isObject(key)) {
-    return _.each(key, function (v, k) {
-      self.register(k, v)
-    });
+    emitLog(this, LOG_LEVEL.INFO, "Registering key/value pairs as constants.")
+    _.each(key, function(v, k) { self.register(k, v); });
+    return this;
   }
 
-  var opts = opts || {},
-      identifier = opts.identifier || key,
-      aggregateOn = opts.aggregateOn,
-      registry = this._registry;
+  opts              = opts || {};
+  var identifier    = opts.identifier || key,
+      aggregateOn   = opts.aggregateOn,
+      registry      = this._registry;
 
   if (_.isString(opts)) {
     identifier = opts;
   }
 
-  if (!_.isUndefined(registry[key])) {
-    var msg = 'Naming conflict encountered. Attempting to register two dependencies with the same name: \n' +
-        '  ' + registry[key].identifier + '\n' +
-        '  ' + identifier + '\n' +
-        'Please resolve this conflict before you run again.'
-    throw new Error(msg)
+  if (this.isRegistered(key)) {
+    msg =
+      'Naming conflict encountered.' +
+      ' Attempting to register two dependencies with the same name: \n' +
+      '  ' + registry[key].identifier + '\n' +
+      '  ' + identifier + '\n' +
+      'Please resolve this conflict before you run again.';
+    throw new Error(msg);
   }
 
   if (!_.isFunction(fn)) {
     throw new Error('Cannot register non-function for dependency injection: ' + identifier);
   }
 
-  var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
-  var FN_ARG_SPLIT = /,/;
-  var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+  emitLog(self, LOG_LEVEL.INFO, "Registering injectable: {0}", key);
 
-  var fn = fn,
-      fnText,
-      argDecl,
-      dependencies,
-      isAsync;
-
-  fnText = fn.toString().replace(STRIP_COMMENTS, '');
-  argDecl = fnText.match(FN_ARGS);
-  dependencies = argDecl[1].split(FN_ARG_SPLIT);
-  dependencies = _.invoke(dependencies, 'trim');
-  if (dependencies[0] === '') {
-    dependencies = [];
-  }
-
-  isAsync = _.contains(dependencies, this._asyncConstant)
+  var dependencies = this.findDependencies(fn);
+  var isAsync      = _.contains(dependencies, this._asyncConstant);
 
   registry[key] = {
-    dependencies: dependencies,
-    identifier: identifier,
-    fn: fn,
-    isAsync: isAsync
+    dependencies : dependencies,
+    identifier   : identifier,
+    // By definition not a constant, but propery 'constant' could somewhere
+    // be interpreted as the value of a given constant.
+    isConstant   : false,
+    fn           : fn,
+    isAsync      : isAsync
   };
 
   if (aggregateOn) {
@@ -143,95 +190,130 @@ Tree.prototype.register = function (key, fn, opts) {
         });
 
         return ret;
-      }
-      aggregate = this.register(aggregateOn, aggregateFn, 'Aggregate for ' + key);
+      };
+
+      // The register function has been updated to return consistent types
+      // and that type is the Tree, which makes the register call chainable.
+      this.register(aggregateOn, aggregateFn, 'Aggregate for ' + key);
+      aggregate = registry[aggregateOn];
     }
     aggregate.dependencies.push(key);
   }
 
-  return registry[key];
-}
+  return this;
+};
 
+/**
+ * Determines if the given key is registered.
+ *
+ * @param key {String} - Name of a registered injectable.
+ * @returns {boolean} - true iff the key has been registered.
+ */
 Tree.prototype.isRegistered = function (key) {
-  return this._registry[key] ? true : false;
-}
+  return !!this._registry[key];
+};
 
-Tree.prototype.resolve = function (callback) {
-  var self = this,
-      registry = this._registry,
-      resolved = this._resolved,
-      resolutionOrder = [],
-      async,
-      unresolved;
+/**
+ *
+ * @param tree
+ * @param registry
+ * @returns {boolean}
+ */
+function hasRegisteredAllDependencies(tree, registry) {
 
-  if (callback) {
-    self.on('error', callback);
-    self.on('resolved', function (resolved) {
-      callback.apply(self, [null, resolved]);
-    });
-  }
+  emitLog(tree, LOG_LEVEL.INFO, "Resolving Tree.");
 
-  //0: Check if any of the registered modules are async; if so, register the done constant as a no-op to avoid errors
-  async = _.findWhere(registry, {isAsync: true});
-  if (async) {
-    this.register(this._asyncConstant, function () {
-    });
-  }
+  // Set state to resolving AFTER registering the async constant to avoid an error.
+  tree._state = STATES.RESOLVING;
 
-  // set state to resolving AFTER registering the async constant to avoid an error
-  self._state = STATES.RESOLVING
-
-  unresolved = _.clone(registry);
+  emitLog(tree, LOG_LEVEL.INFO, "Checking for any unregistered dependencies");
 
   //1: check for modules that have dependencies that have not been registered
-  var allDependencies = _.chain(registry).values().pluck('dependencies').flatten().value(),
-      allRegistered = _.keys(registry),
-      unregisteredDependencies = _.difference(allDependencies, allRegistered);
+  var allDependencies           = _.chain(registry).values().pluck('dependencies').flatten().value();
+  var allRegistered             = _.keys(registry);
+  var unregisteredDependencies  = _.difference(allDependencies, allRegistered);
+
+  emitLog(tree,
+    LOG_LEVEL.INFO,
+    "All dependencies count: {0}, all registered count: {1}, unregistered count: {2}",
+    allDependencies.length,
+    allRegistered.length,
+    unregisteredDependencies.length);
 
   if (unregisteredDependencies.length > 0) {
-    var report = {};
-
-    _.each(unregisteredDependencies, function (dep) {
-      var violaters = _.filter(registry, function (item) {
-        return _.contains(item.dependencies, dep);
-      });
-
-      report[dep] = _.pluck(violaters, 'identifier');
-    });
-
-    var msg = 'Cannot resolve the following dependencies: \n'
-    _.each(report, function (file, dep) {
-      msg += '  ' + dep + ' in ' + file;
-    });
-
-    return emitError(self, msg)
+    emitLog(tree,
+      LOG_LEVEL.DEBUG,
+      "Detected unregistered dependencies: {0}",
+      unregisteredDependencies.length);
+    emitError(tree, createUnregisteredMessage(registry, unregisteredDependencies));
+    return false; // Don't continue (stop continuation).
   }
 
-  // 2: Recursively loop over the unresolved list and push modules into the resolution order list
-  // whose dependencies are already in the resolution order list
-  var prevLength = -1,
-      nextLength = resolutionOrder.length;
+  return true;
+};
+
+function createUnregisteredMessage(registry, unregisteredDependencies) {
+
+  var report = {};
+
+  _.each(unregisteredDependencies, function (dep) {
+    var violaters = _.filter(registry, function (item) {
+      return _.contains(item.dependencies, dep);
+    });
+
+    report[dep] = _.pluck(violaters, 'identifier');
+  });
+
+  msg = 'Cannot resolve the following dependencies: \n';
+  _.each(report, function (file, dep) {
+    msg += '  ' + dep + ' in ' + file;
+  });
+
+  return msg;
+};
+
+
+function hasFoundAllDependencies(tree, registry) {
+  var prevLength      = -1,
+      resolutionOrder = [],
+      nextLength      = resolutionOrder.length,
+      unresolved      = _.clone(registry);
+
+  // Loops at least once with the default values since 0 > -1; where
+  // prevLength defaults to -1, and resolutionOrder defaults to 0.
   while (nextLength > prevLength) {
-    //stall out if we are not continuing to resolve dependencies
-    pushToResolveOrder()
+    // Stall out if we are not continuing to resolve dependencies.
+    pushToResolveOrder(unresolved, resolutionOrder);
     prevLength = nextLength;
     nextLength = resolutionOrder.length;
   }
 
-  function pushToResolveOrder() {
-    _.each(unresolved, function (item, key) {
-      if (_.difference(item.dependencies, resolutionOrder).length == 0) {
-        resolutionOrder.push(key);
-        delete unresolved[key];
+  function pushToResolveOrder(unresolvedDeps, resOrder) {
+    _.each(unresolvedDeps, function (item, key) {
+      if (_.difference(item.dependencies, resOrder).length == 0) {
+        emitLog(tree, LOG_LEVEL.INFO, "Found all dependecies for module: {0}", key);
+        resOrder.push(key);
+        delete unresolvedDeps[key];
       }
-    })
-  }
+    });
+  };
 
   var expectLength = _.keys(registry).length;
-  if (resolutionOrder.length < expectLength) {
+  var hasFoundAll  = resolutionOrder.length >= expectLength
+
+  if (!hasFoundAll) {
+    /*
+     * unresolved - here should be an object with key as the name of
+     * the injected, and an object { dependencies: [] } of it's
+     * required dependencies.
+     */
     var circle = findCircularDependencies(unresolved);
 
     var msg = 'Circular dependency detected! Please check the following files to correct the problem: \n';
+
+    // If circle is empty do you really have an issue?  If circle is
+    // empty this message will be you a Circular dependency, but we
+    // can't help you find it.
     _.each(circle, function (item, index) {
       var first = index == 0;
       var last = index == (circle.length - 1);
@@ -244,88 +326,172 @@ Tree.prototype.resolve = function (callback) {
       }
     });
 
-    return emitError(self, msg)
+    emitError(tree, msg);
   }
 
-  unresolved = _.clone(registry);
+  return hasFoundAll;
+};
 
-  function canBeResolved() {
-    var toResolve = {}
-    _.each(unresolved, function (item, key) {
-      if (_.difference(item.dependencies, _.keys(resolved)).length == 0) {
-        toResolve[key] = item
-        delete unresolved[key]
-      }
-    })
-    return toResolve
+function canBeResolved(unresolved, resolved) {
+  var toResolve = {};
+  _.each(unresolved, function (item, key) {
+    if (_.difference(item.dependencies, _.keys(resolved)).length == 0) {
+      toResolve[key] = item;
+      delete unresolved[key];
+    }
+  });
+  return toResolve;
+};
+
+function registerAsyncPlaceholder(tree, registry, asyncName) {
+  var async = _.findWhere(registry, {isAsync: true})
+  if (async) {
+    emitLog(tree, LOG_LEVEL.INFO,
+      "Detected there exists async injectables." +
+      "  Registering internal async callback." +
+      "  Found: {0} as async.",
+      async.identifier)
+    tree.register(asyncName, function () { });
+  }
+}
+
+
+Tree.prototype.resolve = function (callback) {
+
+  emitLog(this, LOG_LEVEL.INFO, "Registration phase closed.");
+
+  if (callback) {
+    this.on('error', callback);
+    this.on('resolved', callback);
   }
 
-  function doResolving() {
-    if (self._state == STATES.ERROR) return;
+  // 0: Check if any of the registered modules are async; if so,
+  // register the _done constant as a no-op to avoid errors where
+  // the dependency goes unregistered.
+  registerAsyncPlaceholder(this, this._registry, this._asyncConstant);
 
-    var toResolve = canBeResolved()
-    _.each(toResolve, function (mod, key) {
-      var timeout,
-          resolution;
+  if (!hasRegisteredAllDependencies(this, this._registry)) { return this; }
 
-      if (self._asyncTimeout > 0) {
-        timeout = setTimeout(function () {
-          if (self._state == STATES.ERROR) return;
+  // 2: Loops over the unresolved items looking for those that have
+  // fully identified each of it's dependencies.
+  if (!hasFoundAllDependencies(this, this._registry)) { return this; }
 
-          //Throw a timeout error if
-          if (!resolved.hasOwnProperty(key)) {
-            emitError(self, msg)
-          }
-        }, self._asyncTimeout)
-      }
+  // 3: Recursively loop over the unresolved list and push modules
+  // into the resolution order list whose dependencies are already
+  // in the resolution order list
+  var unresolved    = _.clone(this._registry);
+  var registrySize  = _.size(this._registry)
 
-      function doneFn(err, resolution) {
-        clearTimeout(timeout)
-        if (self._state == STATES.ERROR) return;
-
-        if (err) {
-          emitError(self, msg)
-        }
-
-        resolved[key] = resolution;
-
-        // if there are outstanding unresolved functions, recursively run doResolving
-        if (_.size(unresolved) > 0) {
-          doResolving()
-        }
-        // if all modules are resolved, execute callback - this can happen at most once
-        else if (_.size(resolved) == _.size(registry) && self._state == STATES.RESOLVING) {
-          self._state = STATES.RESOLVED
-          return self.emit('resolved', resolved)
-        }
-      }
-
-      if (mod.constant) {
-        resolution = mod.constant;
-      } else {
-        var dependencies = mod.dependencies;
-        var resolvedDependencies = []
-        _.each(dependencies, function (dep) {
-          if (dep == self._asyncConstant) {
-            resolvedDependencies.push(doneFn);
-          } else {
-            resolvedDependencies.push(resolved[dep]);
-          }
-        });
-
-        resolution = mod.fn.apply(self, resolvedDependencies);
-      }
-      if (!mod.isAsync) {
-        // force asynchronous resolution even in the case of synchronously resolving modules, so that a tree can have
-        // event handlers registered after .resolve() has been called.
-        setImmediate(doneFn, null, resolution)
-      }
-    })
-  }
-
-  doResolving();
+  doResolving(this, unresolved, this._resolved, registrySize, 1);
   return this;
 }
+
+function doResolving(self, unresolved, resolved, registrySize, level) {
+
+  if (self._state == STATES.ERROR) {
+    return emitLog(self, LOG_LEVEL.DEBUG,
+      "Error detected.  Skipping unresolved: {0}, resolved: {1}, registry size: {2}",
+      _.size(unresolved),
+      _.size(resolved),
+      registrySize)
+ }
+
+  var toResolve = canBeResolved(unresolved, resolved);
+
+  emitLog(self, LOG_LEVEL.INFO,
+    "Remaining items to resolve: {0}, recursion level: {1}",
+    _.size(toResolve),
+    level || "UNKNOWN")
+
+  _.each(toResolve, function (mod, key) {
+    var timeout, resolution;
+
+    emitLog(self, LOG_LEVEL.INFO, "Resolving: {0}", key);
+
+    if (self._asyncTimeout > 0) {
+      timeout = setTimeout(function () {
+        if (self._state == STATES.ERROR) {
+          return emitLog(self, LOG_LEVEL.DEBUG,
+            "Previous error detected.  Skipping timeout.  Resolution of {0}", key)
+        }
+        if (!resolved.hasOwnProperty(key)) {
+          var message = 'Timeout.  Module \'{0}\' took longer then {1}ms to load.';
+          emitError(self, message, key, self._asyncTimeout);
+        }
+      }, self._asyncTimeout);
+    }
+
+    var doneFn = function(err, resolution) {
+      clearTimeout(timeout);
+      if (self._state == STATES.ERROR) {
+        return emitLog(self, LOG_LEVEL.DEBUG,
+          "Previous error detected.  Skipping resolution of {0}", key)
+      }
+      if (err) {
+        return emitError(self, err);
+      }
+
+      resolved[key] = resolution;
+
+      // if there are outstanding unresolved functions, recursively run doResolving
+      if (_.size(unresolved) > 0) {
+        doResolving(self, unresolved, resolved, registrySize, level + 1);
+      }
+      // if all modules are resolved, execute callback - this can happen at most once
+      else if (_.size(resolved) == registrySize && self._state == STATES.RESOLVING) {
+        emitLog(self, LOG_LEVEL.INFO, 'Transitioning state to {0}', STATES.RESOLVED)
+        self._state = STATES.RESOLVED;
+        emitLog(self, LOG_LEVEL.INFO,
+          'Tree resolution complete. Final module resolved: {0}.', key)
+        return self.emit('resolved', null, resolved);
+      } else {
+        emitLog(self, LOG_LEVEL.DEBUG,
+          'No further processing should be done.  Attached key: {0}.', key)
+      }
+    };
+
+    // Updated to use a flag to denote a constant registered value, instead of the
+    // constant itself, to prevent constants of 0, false, '', and undefined from
+    // posing as 'falsy' here, when they should be resolved as constants.
+    if (mod.isConstant) {
+      resolution = mod.constant;
+    } else {
+
+      var resolvedDependencies = [];
+
+      _.each(mod.dependencies, function (dep) {
+        if (dep == self._asyncConstant) {
+          resolvedDependencies.push(doneFn);
+        } else {
+          resolvedDependencies.push(resolved[dep]);
+        }
+      });
+
+      try {
+        emitLog(self, LOG_LEVEL.INFO,
+          "Applying/resolving module: {0}", mod.identifier)
+        resolution = mod.fn.apply(self, resolvedDependencies);
+      } catch (ex) {
+        emitLog(self, LOG_LEVEL.DEBUG,
+          "Exception thrown during apply/resolution of module: {0}.\n[[{1}]]",
+          mod.identifier,
+          ex.toString()
+        )
+        throw ex;
+      }
+    }
+
+    if (mod.isAsync) {
+      // Resolves async methods via the above doneFn.
+    } else {
+      // Force asynchronous resolution even in the case of synchronously
+      // resolving modules, so that a tree can have event handlers
+      // registered after .resolve() has been called.
+      setImmediate(doneFn, null, resolution);
+    }
+  });
+}
+
 
 /*
 Emits a destroy event so that modules can do any cleanup needed, then clears all event listeners and makes the tree
@@ -344,8 +510,7 @@ Tree.prototype.destroy = function (done) {
 
   this.emit('destroy', function (err) {
     if(err) {
-      console.log('emitting error')
-      emitError(self, err)
+      emitError(self, err);
     }
     callbacksCalled++;
     if (callbacksCalled == callbacksExpected) {
@@ -359,10 +524,10 @@ Tree.prototype.destroy = function (done) {
   else {
     setTimeout(function(){
       if (callbacksCalled != callbacksExpected && self._state != STATES.ERROR) {
-        emitError(self, 'Timeout on destroy')
+        emitError(self, 'Timeout on destroy');
         selfDestruct();
       }
-    }, self._destroyTimeout)
+    }, self._destroyTimeout);
   }
 
   function selfDestruct() {
@@ -370,35 +535,55 @@ Tree.prototype.destroy = function (done) {
     self.removeAllListeners();
 
     // re-initialize the object
-    Tree.call(self)
+    Tree.call(self);
     _.each(destroyedListeners, function(fn){
       fn.apply(self);
     });
   }
-}
+};
 
 /*
-Utility functions
+  Utility functions
+ */
+
+/**
+ * Expects a set of objects with remaining dependencies.  If an item
+ * has zero dependencies then it should have been considered resolvable.
+ *
+ * @param unresolved - A non-empty object.
+ * @returns {*}
  */
 function findCircularDependencies(unresolved) {
+
   var first = _.find(unresolved, function () {
     return true;
-  })
+  });
+
+  if (!first) {
+    return [];
+  }
+
+  /**
+   * We've eliminated the possibility of first being null/undefined in the
+   * previous test.  If first were either this function would throw an
+   * exception.  (Because of the mod.dependencies access.)
+   */
   var circle = walk(first, []);
 
   function walk(mod, path) {
-    //this is not a possible scenario im pretty sure
+    // This possibility should not truly be possible since by definition
+    // a module with 0 dependecies is resolvable.
     if (mod.dependencies.length == 0) {
       return;
     }
 
     var lastElement = path.slice(-1)[0];
     var firstInstance = path.slice(0, -1).indexOf(lastElement);
+
     if (firstInstance >= 0) {
       //we have a circle!
       return path.slice(firstInstance);
     }
-
     else {
       path.push(mod.identifier);
       var nextMod = _.find(mod.dependencies, function (dep) {
@@ -408,17 +593,59 @@ function findCircularDependencies(unresolved) {
 
       return walk(nextMod, path);
     }
-  }
+  };
 
   return circle;
 }
 
+function interpolate(str, obj) {
+  return str.replace(/\{([^{}]*)\}/g,
+    function (a, b) {
+      var r = obj[b];
+      return typeof r === 'string' || typeof r === 'number' ? r : a;
+    });
+};
+
+var LOG_LEVEL = {
+  INFO    : 'info',
+  DEBUG   : 'debug',
+  WARN    : 'warn'
+};
+
+/**
+ * Consider 'supplant' so that we can do something like "message: {0} and {1}"
+ * where the arguments are provided and spliced fr
+ * @param tree
+ * @param level
+ * @param msg
+ */
+function emitLog(tree, level, msg) {
+  if (!level) {
+    return emitError(tree, "Cannot without level: " + level);
+  }
+  if (!_.isString(level)){
+    return emitError(tree, "Cannot emit log with non-string level: " + JSON.stringify(level))
+  }
+  if (!_.has(LOG_LEVEL, (level || "").toUpperCase())) {
+    return emitError(tree, "Cannot emit log unknown-level: " + level)
+  }
+  var args = _.toArray(arguments);
+  if (args.length > 3) {
+    msg = interpolate(msg, args.slice(3));
+  }
+  tree.emit(level, msg);
+};
+
 function emitError(tree, msg){
-  tree._state = STATES.ERROR
+  tree._state = STATES.ERROR;
+  var args = _.toArray(arguments);
   if(!(msg instanceof Error)){
+    if (args.length > 2) {
+      msg = interpolate(msg, args.slice(2));
+    }
     msg = new Error(msg);
   }
-  tree.emit('error', msg)
+  tree.emit('error', msg);
 }
 
 exports.Tree = Tree;

--- a/test/deepTreeTest.js
+++ b/test/deepTreeTest.js
@@ -1,0 +1,203 @@
+var nject       = require('../'),
+    should      = require('should'),
+    _           = require('lodash')
+
+var logger = { log: console.log };
+var opts   = { logger: logger   };
+
+
+describe('deep tree', function() {
+
+//  beforeEach(function() {
+//    nject.Tree.prototype._asyncTimeout    = 500;
+//    nject.Tree.prototype._destroyTimeout  = 500;
+//  });
+
+  describe('registry =>', function() {
+
+    it('should fail with properly reported async timeout on delay', function() {
+      tree = new nject.Tree();
+      tree.register('logger', function() { return console.log; });
+      tree.register('delay', function(logger, _done) { });
+
+      tree.resolve(function(err, res) {
+        (!!err).should.be.true;
+        err.should.be.an.instanceOf(Error);
+        msg = err.toString();
+        msg.should.include('delay');
+      });
+    });
+
+    it('should report that tree resolution has begun (and looger is ready)', function() {
+      tree = new nject.Tree();
+      tree.register('logger', function() { return console.log; });
+      tree.register('delay', function(logger, _done) { _done(null, {}); });
+
+      var args = null;
+      var opts = {
+        logger : {
+          log: function(params) {
+            args = params;
+          }
+        }
+      };
+
+      tree.resolve(function(err, res) {
+        (!!err).should.be.false;
+        args.should.contain("Started tree resolution.");
+      }, opts);
+    });
+
+  });
+
+  describe('findDeps', function() {
+    it('should find zero deps for no param fn', function() {
+      var f = function() { };
+      var tree = new nject.Tree();
+      var deps = tree.findDependencies(f);
+      (!!deps).should.be.true;
+      deps.should.have.length(0);
+    });
+
+    it('should find zero deps for comments in params fn', function() {
+      var f = function( // with some text in params
+      ) { };
+      var tree = new nject.Tree();
+      var deps = tree.findDependencies(f);
+      (!!deps).should.be.true;
+      deps.should.have.length(0);
+    });
+  });
+
+  describe('logging events =>', function() {
+    it('should emit logs for registering constants', function(done) {
+      var log = function(msg) {
+        msg.should.include('yyy');
+        done()
+      }
+      var tree = new nject.Tree();
+      tree.on('info', log)
+      tree.constant('yyy', 1);
+    })
+
+    it('should emit debug for unregistered dependency', function(done) {
+      var calledLog = false
+      var log = function(msg) {
+        calledLog = true
+      }
+      var tree = new nject.Tree();
+      tree.on('debug', log)
+      tree.register('add', function(add, sub) { });
+      tree.resolve(function(err, resolved) {
+        err.should.exist
+        calledLog.should.be.true
+        done()
+      })
+    })
+
+    it('should log all areas', function(done) {
+      var tree = new nject.Tree();
+      var res = {
+        config    : false,
+        _done     : false,
+        sqlPool   : false,
+        Database  : false,
+        HomeCtrl  : false
+      }
+
+      tree.on('info', function(msg) {
+        var keys = _.keys(res)
+        var dep = _.find(keys, function(k) {
+          return new RegExp(k + "$").test(msg);
+        });
+
+        if (!!dep) {
+          res[dep] = true
+        }
+      });
+
+      tree.on('info', function(msg) {
+        console.log('info: ', msg)
+      })
+      tree.on('debug', function(msg) {
+        console.log('debug: ', msg)
+      })
+
+      tree
+        .register('sqlPool', function(config, _done) {
+          setTimeout(function() {
+            _done(null, {})
+          }, 100)
+        })
+        .constant('config', {name:'config'})
+        .register('HomeCtrl', function(Database, config) {
+          return {};
+        })
+        .register('Database', function(sqlPool, _done) {
+          _done(null, {})
+        })
+        .resolve(function(err, resolved) {
+          (!err).should.be.true
+          _.all(_.values(res), function(a) { return a; }).should.be.true
+          done()
+        })
+    })
+
+    it.skip("should run a 'false' constant with async resolution", function() {
+
+    })
+
+    it.skip("should not allow constant registration once an error is detected", function() {
+
+    })
+
+    it.only("should 'debug' log when an injectable throws an error during injection", function(done) {
+      var cHasError = 1;
+      var tree = new nject.Tree();
+      tree.on('info', function(msg) {
+        console.log('info: ', msg)
+      })
+      tree.on('debug', function(msg) {
+        console.log('debug: ', msg)
+      })
+
+      var fn = function() {
+        tree
+          .register('y', function() { return 12; })
+          .register('x', function() { return 11; })
+          .register('d', function(x, y) { cHasError = 100; })
+          .register('a', function(b, c, d, _done) { _done(null, true); })
+          .register('b', function(x, y, _done) { _done(null, 32); })
+          .register('c', function() {
+            cHasError = 2;
+            throw new Error("Purposefully throwing error in module 'c'")
+          })
+          .resolve(function(err, res) {
+            var hasError = !!err
+            hasError.should.be.true
+            cHasError.should.equal(1)
+            done()
+          })
+          .on('error', function(err) {
+            console.log('error', err)
+            (!err).should.be.true
+            cHasError = 22;
+            done();
+          })
+      }
+
+      fn.should.throw(Error)
+    })
+
+    it("should have registered the async constant if no async injectables are registered", function() {
+      var tree = new nject.Tree();
+      tree.constant("un", void(0))
+      tree.resolve(function(err, res) {
+          (!err).should.be.true
+        _.isUndefined(res.un).should.be.true
+      })
+    })
+  })
+
+});
+


### PR DESCRIPTION
targeting areas used to resolve a dependency tree.  In the process
identified a few areas that moderately changed the interface:
1.  The return values for function was made consistent.  Mostly the
   tree is returned for chainability, and where it wasn't before it does
   now.
2.  Before falsy values (false, 0, null, '', undefined) could not be
   added as constants because during resolution the check against the
   constant's value was used to determine async processing, but, of
   course, these constant's are falsy, and so not processed correctly,
   and so isConstant was introduced in the internal registration.
3.  Logging is quite ubiquitous now.  There are places where less
   logging could be done, but instead of rearranging code to require less
   logging the old code was used, and verbose logging added.
4.  In this pass the code wasn't greatly broken appart or refactored
   to not resemble the original.  Instead, the goal was to isolate
   function dependencies, which means to remove closures from places
   where they had access to data they didn't need.  In this way these
   functions could be further refactored to eliminate uneeded state.

All of this is to figure out where dependency resolution is/was/will
fail in the future, and then quickly resolve those issues.
