### PR TITLE
Added/fixed logging of dependencies that require async resolution.

### DIFF
--- a/lib/nject.js
+++ b/lib/nject.js
@@ -353,10 +353,15 @@ function registerAsyncPlaceholder(tree, registry, asyncName) {
   if (async) {
     emitLog(tree, LOG_LEVEL.INFO,
       "Detected there exists async injectables." +
-      "  Registering internal async callback." +
-      "  Found: {0} as async.",
-      async.identifier)
+      "  Registering internal async callback.")
     tree.register(asyncName, function () { });
+
+    _(registry).filter({isAsync: true})
+      .each(function(e) {
+        emitLog(tree, LOG_LEVEL.INFO,
+          "Using single {0} as aync for {1}",
+          asyncName, e.identifier)
+      });
   }
 }
 
@@ -399,7 +404,7 @@ function doResolving(self, unresolved, resolved, registrySize, level) {
       _.size(unresolved),
       _.size(resolved),
       registrySize)
- }
+  }
 
   var toResolve = canBeResolved(unresolved, resolved);
 
@@ -411,10 +416,12 @@ function doResolving(self, unresolved, resolved, registrySize, level) {
   _.each(toResolve, function (mod, key) {
     var timeout, resolution;
 
-    emitLog(self, LOG_LEVEL.INFO, "Resolving: {0}", key);
+    emitLog(self, LOG_LEVEL.INFO, "Resolving: {0} ({1}ms timeout)", key, self._asyncTimeout);
 
+    // This is to say, the 'tree' hasn't shut off timeouts, allowing infinite timeouts
     if (self._asyncTimeout > 0) {
       timeout = setTimeout(function () {
+        emitLog(self, LOG_LEVEL.DEBUG, "Handling timeout callback for: {0} {1}", key, ""+_.has(resolved, key))
         if (self._state == STATES.ERROR) {
           return emitLog(self, LOG_LEVEL.DEBUG,
             "Previous error detected.  Skipping timeout.  Resolution of {0}", key)


### PR DESCRIPTION
Prior to these changes only the first async dependency was logged as
part of detecting if a the '_done' identifier should be
registered.

Additionally, some error logging around the timeout portion of the
code was added.